### PR TITLE
Fix building on anything other than macOS

### DIFF
--- a/Sources/HypertextLiteral/HTML.swift
+++ b/Sources/HypertextLiteral/HTML.swift
@@ -369,7 +369,7 @@ extension HTML: ExpressibleByStringInterpolation {
 
 fileprivate extension StringProtocol {
     var escaped: String {
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if os(macOS)
         return (CFXMLCreateStringByEscapingEntities(nil, String(self) as NSString, nil)! as NSString) as String
         #else
         return [


### PR DESCRIPTION
`CFXMLCreateStringByEscapingEntities` is only available on macOS according to [Apple's reference documentation](https://developer.apple.com/documentation/corefoundation/1542736-cfxmlcreatestringbyescapingentit).