### PR TITLE
Improve handling of boolean attributes

### DIFF
--- a/Sources/HypertextLiteral/Extensions/Swift+HyperTextConvertible.swift
+++ b/Sources/HypertextLiteral/Extensions/Swift+HyperTextConvertible.swift
@@ -60,8 +60,6 @@ extension Bool: HypertextAttributeValueInterpolatable {
 
 extension Dictionary: HypertextAttributesInterpolatable where Key: StringProtocol {
     public func html(in element: String) -> HTML {
-        var attributes: [(name: String, value: String)] = []
-
         func attribute(for key: String, value: Any) -> (name: String, value: String)? {
             guard let interpolatableValue = value as? HypertextAttributeValueInterpolatable else {
                 return (key, "\(value)")
@@ -70,15 +68,15 @@ extension Dictionary: HypertextAttributesInterpolatable where Key: StringProtoco
             return interpolatableValue.html(for: key, in: element).map { (key, $0.description) }
         }
 
-        for (key, value) in self {
+        let attributes = flatMap { (key, value) -> [(name: String, value: String)] in
             switch key {
             case "aria", "data":
                 guard let value = value as? [String: Any] else { fallthrough }
-                for (nestedKey, nestedValue) in value {
-                    attribute(for: "\(key)-\(nestedKey)", value: nestedValue).map { attributes.append($0) }
+                return value.compactMap { (nestedKey, nestedValue) in
+                    attribute(for: "\(key)-\(nestedKey)", value: nestedValue)
                 }
             default:
-                attribute(for: "\(key)", value: value).map { attributes.append($0) }
+                return [attribute(for: "\(key)", value: value)].compactMap { $0 }
             }
         }
 

--- a/Tests/HypertextLiteralTests/HypertextLiteralTests.swift
+++ b/Tests/HypertextLiteralTests/HypertextLiteralTests.swift
@@ -159,7 +159,7 @@ final class HypertextLiteralTests: XCTestCase {
         XCTAssertEqual(html.description, expected)
     }
 
-    func testStringLiteralWithBooleanAttributeInterpolation() throws {
+    func testStringLiteralWithBooleanAttributeInterpolationOfTrueValues() throws {
         let attributes: [String: Any] = [
             "aria": [
                 "label": true
@@ -176,6 +176,28 @@ final class HypertextLiteralTests: XCTestCase {
 
         let expected = #"""
         <input aria-label="true" autocomplete="on" spellcheck="spellcheck" translate="yes" type="text"/>
+        """#
+
+        XCTAssertEqual(html.description, expected)
+    }
+
+    func testStringLiteralWithBooleanAttributeInterpolationOfFalseValues() throws {
+        let attributes: [String: Any] = [
+            "aria": [
+                "label": false
+            ],
+            "autocomplete": false,
+            "spellcheck": false,
+            "translate": false,
+            "type": "text"
+        ]
+
+        let html: HTML = #"""
+        <input \#(attributes)/>
+        """#
+
+        let expected = #"""
+        <input aria-label="false" autocomplete="off" translate="no" type="text"/>
         """#
 
         XCTAssertEqual(html.description, expected)


### PR DESCRIPTION
Those attributes where their presence signifies "true" must not be
rendered to convey "false".
For example: "required" will render as `required="required"`.
But this happens regardless of whether the boolean is true or false.
These changes rectify this situation by not rendering
the attribute in case the value is "false".